### PR TITLE
Feature/left and main link

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -9,6 +9,8 @@ SilverStripe\Admin\LeftAndMain:
   help_links:
     # Add a new link
     'Bespoke CMS User Guide': '/cms-user-guide'
+  extensions:
+    - SilverStripe\Clippy\Extension\DocumentationPageLeftAndMain
 
 SilverStripe\Clippy\PageTypes\DocumentationPage:
   default_url_segment: cms-user-guide

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -10,6 +10,9 @@ SilverStripe\Admin\LeftAndMain:
     # Add a new link
     'Bespoke CMS User Guide': '/cms-user-guide'
 
+SilverStripe\Clippy\PageTypes\DocumentationPage:
+  default_url_segment: cms-user-guide
+
 SilverStripe\Clippy\Controllers\DocumentationPageController:
   docs_dir: /docs/userguides
   screenshots_dir: /docs/userguides/img

--- a/src/Extension/DocumentationPageLeftAndMain.php
+++ b/src/Extension/DocumentationPageLeftAndMain.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace SilverStripe\Clippy\Extension;
+
+use SilverStripe\Admin\CMSMenu;
+use SilverStripe\Admin\LeftAndMainExtension;
+use SilverStripe\Clippy\PageTypes\DocumentationPage;
+use SilverStripe\Core\Config\Config;
+
+class DocumentationPageLeftAndMain extends LeftAndMainExtension
+{
+
+    private static string $menu_icon = 'font-icon-block-media';
+
+    public function init()
+    {
+        // unique identifier for this item. Will have an ID of Menu-$ID
+        $id = 'LinkToDocumentationPage';
+
+        // your 'nice' title
+        $title = 'CMS User Guide';
+
+        // the link you want to item to go to
+        $link = Config::inst()->get(DocumentationPage::class, 'default_url_segment');
+
+        // priority controls the ordering of the link in the stack. The
+        // lower the number, the lower in the list
+        $priority = -2;
+
+        // Add your own attributes onto the link. In our case, we want to
+        // open the link in a new window (not the original)
+        $attributes = [
+            'target' => '_blank',
+            'title' => 'Bespoke CMS User Guide (opens in a new tab)'
+        ];
+
+        $iconClass = 'font-icon-book-open';
+
+        CMSMenu::add_link($id, $title, $link, $priority, $attributes, $iconClass);
+    }
+}

--- a/src/Pagetypes/DocumentationPage.php
+++ b/src/Pagetypes/DocumentationPage.php
@@ -4,6 +4,7 @@ namespace SilverStripe\Clippy\PageTypes;
 
 use Page;
 use SilverStripe\Clippy\Controllers\DocumentationPageController;
+use SilverStripe\Core\Config\Config;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\LiteralField;
 use SilverStripe\Forms\ReadonlyField;
@@ -121,6 +122,7 @@ class DocumentationPage extends Page
             if (!DocumentationPage::get()->first()) {
                 $DocumentationPage = new DocumentationPage();
                 $DocumentationPage->Title = 'CMS User Guide';
+                $DocumentationPage->URLSegment = Config::inst()->get(DocumentationPage::class, 'default_url_segment');
                 $DocumentationPage->Content = '';
                 $DocumentationPage->write();
                 $DocumentationPage->copyVersionToStage(Versioned::DRAFT, Versioned::LIVE);


### PR DESCRIPTION
- LeftAndMain extension to add link for opening frontend CMS User Guide in a new tab
- Added default URLSegment to `DocumentationPage` in config (also used when generating default record)